### PR TITLE
Feature: Promised Components

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@
 > [operator](https://github.com/estrattonbailey/operator) – where page
 > transitions can make conventional JS patterns cumbersome.
 
+**Note**: You’ll need to polyfill `Promise` for browsers that don’t support it.
+
 ## Install
 ```
 npm i picoapp --save
@@ -44,7 +46,40 @@ const app = picoapp({ button })
 
 To bind your component to the DOM node, call `mount()`:
 ```javascript
-app.mount()
+app.mount() // returns a promise which resolves when all components successfully mount
+```
+
+## Adding Components
+If you need to add components – maybe asynchronously – you can use `add`:
+```javascript
+app.add({
+  modal: component(context => {})
+})
+
+app.mount() // bind the newly added component to the DOM
+```
+
+Additionally, you can pass arbitrary promises that resolve to a component:
+```javascript
+import { picoapp } from 'picoapp'
+import button from './button.js'
+
+const components = { button }
+
+// check for native image lazy-loading
+if (!'loading' in HTMLImageElement.prototype) {
+  const lazyImage = import('lazy-image-fallback.mjs').then(module => module.default)
+  components.push(lazyImage)
+}
+
+const app = picoapp(components) // components.lazyImage is a promise
+```
+
+```javascript
+// lazy-image-fallback.mjs
+export default component((node, ctx) => {
+…
+})
 ```
 
 ## State & Events
@@ -164,13 +199,6 @@ app.hydrate({ count: 5 })
 And then access it from anywhere:
 ```javascript
 app.getState() // { count: 5 }
-```
-
-If you need to add components – maybe asynchronously – you can use `add`:
-```javascript
-app.add({
-  lazyImage: component(context => {})
-})
 ```
 
 If `data-component` isn't your style, or you'd like to use different types of

--- a/test.js
+++ b/test.js
@@ -42,19 +42,24 @@ test('events', t => {
   app.emit('a')
   app.emit('b')
 })
-test('mount', t => {
-  t.plan(1)
+test('mount', async t => {
+  t.plan(2)
 
-  const app = picoapp({
-    foo: component((node, ctx) => {
+  const createComponent = () => {
+    return component((node, ctx) => {
       const u = ctx.on('foo', () => {
         t.pass()
         u() // unsub itself
       })
     })
+  }
+
+  const app = picoapp({
+    foo: createComponent(),
+    bar: Promise.resolve(createComponent()) // async component
   }, { bar: true })
 
-  app.mount()
+  await app.mount()
 
   app.emit('foo')
 
@@ -62,7 +67,7 @@ test('mount', t => {
 
   app.emit('foo')
 })
-test('unmount', t => {
+test('unmount', async t => {
   t.plan(4)
   
   const app = picoapp({
@@ -75,7 +80,7 @@ test('unmount', t => {
     })
   })
 
-  app.mount()
+  await app.mount()
   
   app.emit('foo')
   


### PR DESCRIPTION
Each passed component is now wrapped in a `Promise.resolve`, which has the following consequences:

1. You can now pass promise-wrapped components to `picoapp` and `appInstance.add`.
1. Picoapp requires that `Promise` be polyfilled for browsers that don’t support it.
1. `appInstance.mount()` returns a `Promise` that resolves when all components have been successfully resolved and bound to the DOM.